### PR TITLE
Client side support to provide user feedback.

### DIFF
--- a/assets/new_member_waiting_period.coffee
+++ b/assets/new_member_waiting_period.coffee
@@ -1,0 +1,16 @@
+Session = require 'shared/services/session'
+AbilityService = require 'shared/services/ability_service'
+
+angular.module('loomioApp').config ['$provide', ($provide) ->
+  $provide.decorator 'pollCommonActionPanelDirective', ['$delegate', ($delegate) ->
+
+    $delegate[0].compile = ->
+      ($scope, elem) ->
+        # Override the userCanParticipate to also check how long user has been a member
+        $scope.userCanParticipate = ->
+          AbilityService.canParticipateInPoll($scope.poll) &&
+            Session.user().createdAt.isBefore(moment().subtract(30, 'days'))
+
+    $delegate
+  ]
+]

--- a/config/locales/new_member_waiting_period.en.yml
+++ b/config/locales/new_member_waiting_period.en.yml
@@ -1,0 +1,3 @@
+en:
+  poll_common_action_panel:
+    unable_to_vote: You do not have permission to vote in this decision. If you have been a member for less than 30 days you can only vote in-person.

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,11 +4,17 @@ module Plugins
             setup! :new_member_waiting_period do |plugin|
                 plugin.enabled = true
 
+                # This ability adds the server-side restriction
                 plugin.use_class 'models/ability/new_member_waiting_period'
                 plugin.extend_class Ability::Base do
                     prepend Ability::NewMemberWaitingPeriod
                 end
 
+                # This asset adds the client-side restriction
+                plugin.use_asset 'assets/new_member_waiting_period.coffee'
+
+                # This updates the wording of the client-side error message
+                plugin.use_translations("config/locales", :new_member_waiting_period)
             end
         end
     end


### PR DESCRIPTION
* Adds a new coffeescript override for the pollCommonActionPanelDirective which wraps all of the various poll types. Only the userCanParticpate function gets overridden (the rest of the directive is unmodified).

* Adds a translation that updates the text of the existing error message instead of modifying the HTML.